### PR TITLE
Match features to prevent surprising errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rg"
-version = "0.2.2"
+version = "0.2.1"
 description = "You don't want this crate - you want the `ripgrep` crate"
 license = "Unlicense"
 repository = "https://github.com/BurntSushi/rg-cratesio-typosquat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rg"
-version = "0.2.1"
+version = "0.2.2"
 description = "You don't want this crate - you want the `ripgrep` crate"
 license = "Unlicense"
 repository = "https://github.com/BurntSushi/rg-cratesio-typosquat"
@@ -9,3 +9,6 @@ edition = "2021"
 [[bin]]
 name = "rg"
 path = "main.rs"
+
+[features]
+pcre2 = []


### PR DESCRIPTION
Landed on this crate because of the expected use case of accidentally trying to `cargo install rg` -- except I sometimes do use PCRE2 specifically, so I didn't get the proper suggestion of using `ripgrep`. Instead I was greeted by `the package 'rg' does not contain this feature: pcre2`.

This PR should make it compile even with the only feature currently offered by `ripgrep`